### PR TITLE
Fix ./configure --ipv6 for Deadwood

### DIFF
--- a/configure
+++ b/configure
@@ -168,7 +168,8 @@ else
 	cp tcp/Makefile.ipv6 tcp/Makefile
 	cp dns/Makefile.authonly dns/Makefile
 	cp tools/Makefile.ipv6 tools/Makefile
-	cp deadwood-*/src/Makefile.ipv6 deadwood-*/src/Makefile
+	deadwood_dir=$(ls --directory deadwood-*)
+	cp ${deadwood_dir}/src/Makefile.ipv6 ${deadwood_dir}/src/Makefile
 fi
 
 echo


### PR DESCRIPTION
Shell globbing does not work for non-existing files:
cp: cannot create regular file 'deadwood-*/src/Makefile': No such file or directory